### PR TITLE
Update documentation and add advanced usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,41 +2,47 @@
 
 EloquentRegex brings the simplicity and elegance to regular expressions. Designed for Laravel developers, this package offers a fluent, intuitive interface for building and executing regex patterns in your PHP applications.
 
+```php
+EloquentRegex::source('test@example.com')->email()->check();
+```
+
+Like what we're doing? Show your support with a quick star, please! ⭐
+
 ### Table of Contents
 
-- [Overview](#overview)
-  - [Key Features](#key-features)
-  - [Getting Started](#getting-started)
-- [Basic Usage](#basic-usage)
-  - [Ready-to-Use Patterns](#ready-to-use-patterns)
-  - [Custom Patterns](#custom-patterns)
-    - [Creating a Custom Pattern](#creating-a-custom-pattern)
-  - [Applying Quantifiers](#applying-quantifiers)
-    - [Optional Elements](#optional-elements)
-    - [Specifying a Range](#specifying-a-range)
-    - [One or More](#one-or-more)
-    - [Zero or More](#zero-or-more)
-    - [Exact Number](#exact-number)
-    - [Custom Character Sets and Groups](#to-custom-character-sets-and-groups)
-    - [Quantifier Values](#quantifier-values)
-- [Advanced usage](#advanced-usage)
-  - [Options](#options)
-    - [Options as extra assertions](#options-as-extra-assertions)
-    - [Options as filters](#options-as-filters)
-    - [Options list](#options-list)
-    - [Options in custom patterns](#options-in-custom-patterns)
-  - [Regex Flags](#regex-flags)
-    - [Case-Insensitive Matching](#case-Insensitive-matching)
-    - [Multiline Matching](#multiline-matching)
-    - [Single-Line Mode](#single-line-mode)
-    - [Unicode Character Matching](#unicode-character-matching)
-- [Advanced builderPattern methods](#advanced-builderpattern-methods)
-  - [Character Sets](#character-sets)
-  - [Groups](#groups)
-    - [Capturing Groups](#capturing-groups)
-    - [Non-Capturing Groups](#non-capturing-groups)
-    - [Groups with quantifier](#groups-with-quantifier)
-  - [Conditional matching](#conditional-matching)
+- **[Overview](#overview)**
+  - 🔑[Key Features](#key-features)
+  - 🧭[Getting Started](#getting-started)
+- **[Basic Usage](#basic-usage)**
+  - 📑[Ready-to-Use Patterns](#ready-to-use-patterns)
+  - 🛠️[Custom Patterns](#custom-patterns)
+    - 💠 [Creating a Custom Pattern](#creating-a-custom-pattern)
+  - #️⃣[Applying Quantifiers](#applying-quantifiers)
+    - 💠 [Optional Elements](#optional-elements)
+    - 💠 [Specifying a Range](#specifying-a-range)
+    - 💠 [One or More](#one-or-more)
+    - 💠 [Zero or More](#zero-or-more)
+    - 💠 [Exact Number](#exact-number)
+    - 💠 [Custom Character Sets and Groups](#to-custom-character-sets-and-groups)
+    - 💠 [Quantifier Values](#quantifier-values)
+- **[Advanced usage](#advanced-usage)**
+  - ⚙️[Options](#options)
+    - 💠 [Options as extra assertions](#options-as-extra-assertions)
+    - 💠 [Options as filters](#options-as-filters)
+    - 💠 [Options list](#options-list)
+    - 💠 [Options in custom patterns](#options-in-custom-patterns)
+  - 🚩[Regex Flags](#regex-flags)
+    - 💠 [Case-Insensitive Matching](#case-insensitive-matching)
+    - 💠 [Multiline Matching](#multiline-matching)
+    - 💠 [Single-Line Mode](#single-line-mode)
+    - 💠 [Unicode Character Matching](#unicode-character-matching)
+- **[Advanced builderPattern methods](#advanced-builderpattern-methods)**
+  - 🗃️[Character Sets](#character-sets)
+  - 📦[Groups](#groups)
+    - 💠 [Capturing Groups](#capturing-groups)
+    - 💠 [Non-Capturing Groups](#non-capturing-groups)
+    - 💠 [Groups with quantifier](#groups-with-quantifier)
+  - ❓[Conditional matching](#conditional-matching)
 
 # Overview
 
@@ -49,7 +55,16 @@ Enter **EloquentRegex**. Our goal is to make working with regex in Laravel not j
 EloquentRegex is a PHP/Laravel package that offers a fluent, intuitive interface for constructing and executing regular expressions. Whether you need to validate user input, parse text, or extract specific information from strings, EloquentRegex makes it simple and straightforward. For example:
 
 ```php
-$isValid = EloquentRegex::source('test@example.com')->email()->check();
+$link = 'https://www.example.com/home';
+$isValidUrl = EloquentRegex::source($link)->url()->check();
+```
+
+**Or**
+
+```php
+$isStrong = EloquentRegex::source("StrongP@ssw0rd")->password(function($string) {
+    return $string->minLength(8)->minUppercase(1)->minNumbers(1)->minSpecialChars(1);
+})->check();
 ```
 
 ## Key Features
@@ -803,7 +818,7 @@ Assertion groups allow for conditional matching based on the presence (positive)
 
 #### Positive Lookahead and Lookbehind Assertions
 
-**Example: Using lookAhead Assertions**
+_Example: Using lookAhead Assertions_
 
 Matches digits only if they are followed by a 'D'
 
@@ -816,7 +831,7 @@ EloquentRegex::start('3D')
 // While using "get()" method, 'D' doesn't appear in matches
 ```
 
-**Example: Using lookBehind Assertions**
+_Example: Using lookBehind Assertions_
 
 Matches digits only if they are preceded by a 'P'
 
@@ -845,7 +860,7 @@ EloquentRegex::start($string)
 // While using "get()" method, '-' doesn't appear in matches
 ```
 
-**Example: Using negativeLookBehind Assertions**
+_Example: Using negativeLookBehind Assertions_
 
 Matches digits only if they aren't preceded by a '-'
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ $isValidUrl = EloquentRegex::source($link)->url()->check(); // true
 **Another:**
 
 ```php
-$isStrong = EloquentRegex::source("StrongP@ssw0rd")->password(function($string) {
-    return $string->minLength(8)->minUppercase(1)->minNumbers(1)->minSpecialChars(1);
+$isStrong = EloquentRegex::source("StrongP@ssw0rd")->password(function($options) {
+    $options->minLength(8)->minUppercase(1)->minNumbers(1)->minSpecialChars(1);
 })->check(); // true
 ```
 
@@ -87,13 +87,11 @@ _For more details about package and it's inner workings check out [STRUCTURE.md]
 
 ## Getting Started
 
-Simply install the package via Composer, and you're ready to take the pain out of regex in your PHP/Laravel applications. Follow our quick start guide below to dive in.
+Simply install the package via Composer, and you're ready to take the pain out of regex in your PHP/Laravel applications. Run for installation:
 
 ```bash
 composer require maestroerror/eloquent-regex
 ```
-
-Later, here will be added our quick start guide.
 
 Remember, regex doesn't have to be a source of frustration. With EloquentRegex, you're on your way to becoming a regex master, all while writing cleaner, more maintainable Laravel code.
 
@@ -127,7 +125,7 @@ Let's break it down:
 EloquentRegex::source($yourString);
 ```
 
-- **_Pattern_** Could be method for one of the ready-to-use patterns or your custom pattern (we will talk about custom pattern later). Let's keep the example simple and add url pattern:
+- **_Pattern_** Could be method for one of the ready-to-use patterns or your custom pattern (we will talk about custom patterns later). Let's keep the example simple and add url pattern:
 
 ```php
 EloquentRegex::source($yourString)->url();
@@ -916,13 +914,12 @@ EloquentRegex::start($string)
     - Lookaheads ✔️
     - orPattern
     - Raw methods
-  - Add section in docs for "lazy" method
+    - Add section in docs for "lazy" method
   - Add sections:
     - Testing and Debugging
     - Credits
     - Contributing (+STRUCTURE.md)
     - FAQs
-    - Creating new patterns
 
 ##### Coming next
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ EloquentRegex brings the simplicity and elegance to regular expressions. Designe
     - [Exact Number](#exact-number)
     - [Custom Character Sets and Groups](#to-custom-character-sets-and-groups)
     - [Quantifier Values](#quantifier-values)
+- [Advanced usage](#advanced-usage)
 
 # Overview
 
@@ -369,6 +370,74 @@ EloquentRegex::start($yourString)->digits(5);
 EloquentRegex::start($yourString)->digitsRange(1, 5); // Matches from 1 to 5 digits
 ```
 
+# Advanced usage
+
+As you become more comfortable with the basics of EloquentRegex, you might find yourself needing to tackle more complex string manipulation challenges. The "Advanced Usage" section is designed to take your skills to the next level.
+
+Whether you're dealing with intricate string formats, dynamic pattern requirements, or simply looking to optimize your regex operations for performance and clarity, this section will guide you through the advanced features of EloquentRegex. You'll learn how to leverage the full power of this package to make your Laravel application's text processing as efficient and effective as possible.
+
+## Options
+
+EloquentRegex provides a flexible system for applying options to your patterns. These options can serve as extra assertions to refine pattern matching or act as filters to select only specific matches. There are three main ways to apply options: directly as arguments, through a callback, and via an associative array.
+
+#### Direct Arguments
+
+Pass options directly as arguments to pattern methods for straightforward use cases.
+
+```php
+EloquentRegex::source("StrongP@ssw0rd")->password(8, 1, 1, 1)->check();
+```
+
+#### Callback
+
+A callback offers the most flexibility, allowing any option to be applied to any pattern. Also, It's the recommended approach for complex configurations to keep your code simple and readible.
+
+```php
+EloquentRegex::source("StrongP@ssw0rd")->password(function($pattern) {
+  $pattern->minLength(8)->minUppercase(1)->minNumbers(1)->minSpecialChars(1);
+})->check();
+
+```
+
+#### Associative Array
+
+Options can also be specified using an associative array, providing a clear and concise way to configure multiple options at once.
+
+```php
+EloquentRegex::source("StrongP@ssw0rd")
+->password([
+  "minLength" => 8,
+  "minUppercase" => 1,
+  "minNumbers" => 1,
+  "minSpecialChars" => 1,
+])->check();
+```
+
+_Note: To keep it simple - all option methods have exactly one argument_
+
+### Options as extra assertions
+
+Options can make extra assertions (while using `check` or `checkString` methods) beyond the basic pattern match, ensuring that matches meet specific criteria.
+
+```php
+// The "filePath" pattern matches any file path
+// While "pathType" option Asserts the file path is an absolute
+EloquentRegex::source("/var/www/html/index.php")
+  ->filePath(["pathType" => "absolute"])
+  ->check();
+```
+
+### Options as filters
+
+In some cases (While using `get` method), options serve to filter the results obtained from a pattern match, allowing only certain matches to pass through.
+
+```php
+$string = "Visa: 4111 1111 1111 1111, MasterCard: 5500 0000 0000 0004, Amex: 3400 000000 00009";
+// The "creditCardNumber" pattern matches any credit card number
+// While "cardTypes" (#1 argument) option filters and returns only VISA and AMEX accordingly
+$cards = EloquentRegex::source($string)->creditCardNumber("visa, amex")->get();
+```
+
 ---
 
 ##### To Do
@@ -382,8 +451,8 @@ EloquentRegex::start($yourString)->digitsRange(1, 5); // Matches from 1 to 5 dig
 - Write documentation (add credit for https://regexr.com/ and ChatGPT)
   - Create quick start guide and add in Docs.
   - Add advanced usage section in Docs:
-    - Options and Assertions: Detailed explanation of options, how to apply them, and their effects on patterns.
-    - Filters in Extraction: Using options as filters during extraction and the types of filters available.
+    - Options and Assertions: Detailed explanation of options, how to apply them, and their effects on patterns. ✔️
+    - Filters in Extraction: Using options as filters during extraction and the types of filters available. ✔️
     - Regex Flags: Guide on applying regex flags to patterns for specialized matching behavior.
     - Grouping and Capturing: How to use groups (capturing and non-capturing) and apply quantifiers to them.
   - Add section in docs for "lazy" method

--- a/README.md
+++ b/README.md
@@ -52,11 +52,13 @@ Regular expressions (regex) are powerful, no doubt. They're the Swiss Army knife
 
 Enter **EloquentRegex**. Our goal is to make working with regex in Laravel not just bearable, but actually enjoyable. Yes, you heard that right—**enjoyable**!
 
-EloquentRegex is a PHP/Laravel package that offers a fluent, intuitive interface for constructing and executing regular expressions. Whether you need to validate user input, parse text, or extract specific information from strings, EloquentRegex makes it simple and straightforward. For example:
+EloquentRegex is a PHP/Laravel package that offers a fluent, intuitive interface for constructing and executing regular expressions. Whether you need to validate user input, parse text, or extract specific information from strings, EloquentRegex makes it simple and straightforward.
+
+**For example:**
 
 ```php
 $link = 'https://www.example.com/home';
-$isValidUrl = EloquentRegex::source($link)->url()->check();
+$isValidUrl = EloquentRegex::source($link)->url()->check(); // true
 ```
 
 **Another:**
@@ -64,13 +66,14 @@ $isValidUrl = EloquentRegex::source($link)->url()->check();
 ```php
 $isStrong = EloquentRegex::source("StrongP@ssw0rd")->password(function($string) {
     return $string->minLength(8)->minUppercase(1)->minNumbers(1)->minSpecialChars(1);
-})->check();
+})->check(); // true
 ```
 
-**One more:** 😄
+**One more** 😄
 
 ```php
 EloquentRegex::start("#hello #world This is a #test")->hash()->text()->get();
+// ['#hello', '#world', '#test']
 ```
 
 ## Key Features

--- a/README.md
+++ b/README.md
@@ -907,7 +907,7 @@ In this example, we precisely match "alt=" using the `exact` method. We then cre
 
 The `orPattern` method also accepts a quantifier as its **second argument** (after callback), applying the same [quantifier logic](#quantifier-values) as elsewhere in EloquentRegex. This feature adds another layer of flexibility, allowing you to specify how many times either pattern should be present.
 
-## Raw Methods 🧩
+## Raw Methods🧩
 
 When working with regular expressions, there are times you'll need to insert a segment of raw regex directly into your pattern. This might be due to the complexity of the pattern or simply because you're integrating an existing regex snippet. EloquentRegex accommodates this need with specific methods designed to seamlessly integrate raw regex patterns into your larger expressions.
 
@@ -915,7 +915,7 @@ When working with regular expressions, there are times you'll need to insert a s
 
 The `addRawRegex` method allows you to insert any raw regex directly into your pattern. This is particularly useful for incorporating standard regex snippets without modification.
 
-**Example: Matching a Social Security Number (SSN)**
+**_Example: Matching a Social Security Number (SSN)_**
 
 ```php
 // Directly adds a raw regex pattern for an SSN
@@ -931,7 +931,7 @@ This method is straightforward and ensures that your EloquentRegex pattern can a
 
 Sometimes, you may want to include a raw regex snippet as part of a larger pattern without capturing its match. The `addRawNonCapturingGroup` method wraps the provided raw regex in a non-capturing group, allowing it to participate in the match without affecting the captured groups.
 
-**Example: Adding Digits Followed by a Specific Letter**
+**_Example: Adding Digits Followed by a Specific Letter_**
 
 ```php
 // Wraps digits in a non-capturing group and expects an 'A' immediately after
@@ -949,7 +949,8 @@ In the world of regular expressions, greediness refers to the tendency of quanti
 
 The `lazy()` method modifies the behavior of quantifiers that follow it in the pattern, making them match as few characters as possible. This is particularly useful when you want to extract specific segments from a larger block of text without capturing unnecessary parts.
 
-**Example: Extracting "Secret Coded" Messages from Text**
+**_Example: Extracting "Secret Coded" Messages from Text_**
+
 Consider a situation where you need to extract coded messages enclosed in curly braces and preceded by a specific keyword within a larger text. Using the greedy approach might lead to capturing more text than intended, including text between messages. The `lazy()` method ensures that only the content directly within the braces, following the keyword, is matched.
 
 ```php
@@ -964,8 +965,7 @@ $matches = EloquentRegex::source($text)
     })
     ->get();
 
-// Expected to extract ['message one', 'another hidden text'] as separate matches
-
+// Extracts ['message one', 'another hidden text'] as separate matches
 ```
 
 In this example, without the `lazy()` method, the pattern might greedily match from the first `{secret: ` to the last `}`, including everything in between as a single match (`message one} more text {secret: another hidden text`). By applying `lazy()`, the pattern instead matches the smallest possible string that satisfies the pattern within each set of curly braces, effectively separating the messages.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ EloquentRegex brings the simplicity and elegance to regular expressions. Designe
     - [Custom Character Sets and Groups](#to-custom-character-sets-and-groups)
     - [Quantifier Values](#quantifier-values)
 - [Advanced usage](#advanced-usage)
+  - [Options]
+    - [Options as extra assertions](#options-as-extra-assertions)
+    - [Options as filters](#options-as-filters)
+    - [Options list](#options-list)
 
 # Overview
 
@@ -438,6 +442,141 @@ $string = "Visa: 4111 1111 1111 1111, MasterCard: 5500 0000 0000 0004, Amex: 340
 $cards = EloquentRegex::source($string)->creditCardNumber("visa, amex")->get();
 ```
 
+### Options in custom patterns
+
+```php
+// example of using end() method with option
+```
+
+### Options list
+
+Below is a list of all available options for now. As previously mentioned, options can be applied to any pattern using either a callback or an array.
+
+While this flexibility allows you to tailor your regex patterns precisely, it's important to understand that some options more specific and some are more global in terms of appliance. Choosing the right option depends on the specifics of your use case.
+
+I grouped options by the classes behind them to make their purpose more clear:
+
+- Length options
+
+```php
+public function minLength(int $minLength);
+public function maxLength(int $maxLength);
+public function length(int $exactLength);
+```
+
+- Numbers options
+
+```php
+public function minNumbers(int $minDigits);
+public function maxNumbers(int $maxDigits);
+public function minDigits(int $minDigits);
+public function maxDigits(int $maxDigits);
+public function numberAmount(int $exactAmountOfDigits);
+```
+
+- Character options
+
+```php
+public function allowChars(array $characters);
+public function excludeChars(array $characters);
+public function minUppercase(int $minAmount);
+public function minLowercase(int $maxAmount);
+public function minSpecialChars(int $minAmount);
+public function maxSpecialChars(int $maxAmount);
+public function noSpecialChars(bool $disable = true);
+public function onlyLowercase(bool $only = true);
+public function onlyUppercase(bool $only = true);
+```
+
+_Note: Options having default value can be used without arguments (`noSpecialChars()`) in callback, but it needs argument while using array `["noSpecialChars" => true]`_
+
+- IPv6 option
+
+```php
+public function validIPv6();
+```
+
+- File options
+
+```php
+public function isFile(string|null $extension = null);
+public function isDirectory(int $check = 1);
+```
+
+- File Exists option
+
+```php
+public function fileExists(bool $check = true);
+```
+
+- Specific Currencies options
+
+```php
+public function specificCurrencies(array|string $currencies);
+public function onlyUSD($only = true);
+public function onlyEUR($only = true);
+public function onlyGBP($only = true);
+public function onlyGEL($only = true);
+```
+
+- Path type option
+
+```php
+// Allowed values int 1; string "absolute" | int 2; string "relative";
+public function pathType(string|int $value = 0);
+```
+
+- Country Code option
+
+```php
+public function countryCode(string $code);
+```
+
+- Space options
+
+```php
+public function noSpaces(bool $disallow = true);
+public function noDoubleSpaces(bool $disallow = true);
+public function maxSpaces(int $max);
+```
+
+- Domain specific options
+
+```php
+public function onlyDomains(array|string $domains);
+public function onlyExtensions(array|string $extensions);
+```
+
+- Protocol options
+
+```php
+public function onlyProtocol(string|array $protocol);
+public function onlyHttp(bool $only = true);
+public function onlyHttps(bool $only = true);
+```
+
+- Card Type options
+
+```php
+public function onlyVisa(bool $only = true);
+public function onlyMasterCard(bool $only = true);
+public function onlyAmex(bool $only = true);
+public function cardTypes(string $cardTypes);
+```
+
+- onlyAlphanumeric option
+
+```php
+public function onlyAlphanumeric(bool $only = true);
+```
+
+- HTML tag options
+
+```php
+public function onlyTags(array|string $tags);
+public function restrictTags(array|string $tags);
+```
+
 ---
 
 ##### To Do
@@ -453,6 +592,7 @@ $cards = EloquentRegex::source($string)->creditCardNumber("visa, amex")->get();
   - Add advanced usage section in Docs:
     - Options and Assertions: Detailed explanation of options, how to apply them, and their effects on patterns. ✔️
     - Filters in Extraction: Using options as filters during extraction and the types of filters available. ✔️
+    - Options list
     - Regex Flags: Guide on applying regex flags to patterns for specialized matching behavior.
     - Grouping and Capturing: How to use groups (capturing and non-capturing) and apply quantifiers to them.
   - Add section in docs for "lazy" method

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ EloquentRegex brings the simplicity and elegance to regular expressions. Designe
   - [Groups](#groups)
     - [Capturing Groups](#capturing-groups)
     - [Non-Capturing Groups](#non-capturing-groups)
+    - [Groups with quantifier](#groups-with-quantifier)
 
 # Overview
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Like what we're doing? Show your support with a quick star, please! ⭐
     - 💠 [Groups with quantifier](#groups-with-quantifier)
   - ❓[Conditional matching](#conditional-matching)
   - ⚖️[Pattern alternation (orPattern)](#pattern-alternation-orpattern)
+  - 🧩[Raw Methods](#raw-methods)
+  - 🐌[The Lazy Quantifier Method](#the-lazy-quantifier-method)
 
 # Overview
 
@@ -905,7 +907,74 @@ In this example, we precisely match "alt=" using the `exact` method. We then cre
 
 The `orPattern` method also accepts a quantifier as its **second argument** (after callback), applying the same [quantifier logic](#quantifier-values) as elsewhere in EloquentRegex. This feature adds another layer of flexibility, allowing you to specify how many times either pattern should be present.
 
----
+## Raw Methods 🧩
+
+When working with regular expressions, there are times you'll need to insert a segment of raw regex directly into your pattern. This might be due to the complexity of the pattern or simply because you're integrating an existing regex snippet. EloquentRegex accommodates this need with specific methods designed to seamlessly integrate raw regex patterns into your larger expressions.
+
+#### Adding Raw Regex Patterns
+
+The `addRawRegex` method allows you to insert any raw regex directly into your pattern. This is particularly useful for incorporating standard regex snippets without modification.
+
+**Example: Matching a Social Security Number (SSN)**
+
+```php
+// Directly adds a raw regex pattern for an SSN
+EloquentRegex::start('123-45-6789')
+    ->addRawRegex('\d{3}-\d{2}-\d{4}')
+    ->check();
+// Expected to match an SSN format '123-45-6789', but not '123456789'
+```
+
+This method is straightforward and ensures that your EloquentRegex pattern can accommodate complex requirements with ease.
+
+#### Wrapping Raw Regex in a Non-Capturing Group
+
+Sometimes, you may want to include a raw regex snippet as part of a larger pattern without capturing its match. The `addRawNonCapturingGroup` method wraps the provided raw regex in a non-capturing group, allowing it to participate in the match without affecting the captured groups.
+
+**Example: Adding Digits Followed by a Specific Letter**
+
+```php
+// Wraps digits in a non-capturing group and expects an 'A' immediately after
+EloquentRegex::source('123A')
+    ->addRawNonCapturingGroup('\d', "oneOrMore")->exact('A')
+    ->check();
+// Expected to match '123A' but not 'A123'
+```
+
+## The Lazy Quantifier Method🐌
+
+In the world of regular expressions, greediness refers to the tendency of quantifiers to match as much of the input as possible. However, there are scenarios where you want your pattern to match the smallest possible part of the input that satisfies the pattern, a behavior known as "laziness" or "non-greediness". EloquentRegex introduces a straightforward way to apply this concept through the `lazy()` method.
+
+#### How the Lazy Method Works
+
+The `lazy()` method modifies the behavior of quantifiers that follow it in the pattern, making them match as few characters as possible. This is particularly useful when you want to extract specific segments from a larger block of text without capturing unnecessary parts.
+
+**Example: Extracting "Secret Coded" Messages from Text**
+Consider a situation where you need to extract coded messages enclosed in curly braces and preceded by a specific keyword within a larger text. Using the greedy approach might lead to capturing more text than intended, including text between messages. The `lazy()` method ensures that only the content directly within the braces, following the keyword, is matched.
+
+```php
+$text = "Normal text {secret: message one} more text {secret: another hidden text} end";
+$matches = EloquentRegex::source($text)
+    ->lookBehind(function ($pattern) {
+        $pattern->openCurlyBrace()->exact('secret: ');
+    })
+    ->lazy()->anyChars()
+    ->lookAhead(function ($pattern) {
+        $pattern->closeCurlyBrace();
+    })
+    ->get();
+
+// Expected to extract ['message one', 'another hidden text'] as separate matches
+
+```
+
+In this example, without the `lazy()` method, the pattern might greedily match from the first `{secret: ` to the last `}`, including everything in between as a single match (`message one} more text {secret: another hidden text`). By applying `lazy()`, the pattern instead matches the smallest possible string that satisfies the pattern within each set of curly braces, effectively separating the messages.
+
+#### When to Use the Lazy Method
+
+The `lazy()` method is invaluable when dealing with patterns that include variable-length content, such as strings or blocks of text, where you aim to extract specific, bounded segments. It's especially useful in parsing structured formats embedded within free text, extracting data from templated content, or any scenario where precision is key to separating multiple matches in a larger string.
+
+By making quantifiers lazy, EloquentRegex empowers you to write more precise and effective patterns, ensuring that your matches are exactly as intended, no more and no less.
 
 ##### To Do
 
@@ -935,8 +1004,8 @@ The `orPattern` method also accepts a quantifier as its **second argument** (aft
     - Sets ✔️
     - Lookaheads ✔️
     - orPattern ✔️
-    - Raw methods
-    - Add section in docs for "lazy" method
+    - Raw methods ✔️
+    - Add section in docs for "lazy" method ✔️
   - Add sections:
     - Testing and Debugging
     - Credits

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Like what we're doing? Show your support with a quick star, please! ⭐
     - 💠 [Non-Capturing Groups](#non-capturing-groups)
     - 💠 [Groups with quantifier](#groups-with-quantifier)
   - ❓[Conditional matching](#conditional-matching)
+  - [Pattern alternation (orPattern)](#pattern-alternation-orpattern)
 
 # Overview
 
@@ -882,6 +883,27 @@ EloquentRegex::start($string)
 })->digits()->check();
 // While using "get()" method, '-' doesn't appear in matches
 ```
+
+## Pattern alternation (orPattern)⚖️
+
+Sometimes, you might encounter situations where either one pattern or another is acceptable. For instance, when developing EloquentRegex, a key objective was to enable the reproduction of patterns commonly used in [HSA](https://github.com/MaestroError/html-strings-affixer). Consider the `alt` attribute within an HTML tag, which can be followed by either a double " or a single ' quote. This requirement translates into a regex pattern like `alt\=(\"|')`, indicating an exact match for "alt=" followed by either type of quotation mark.
+
+To achieve this with EloquentRegex, you can utilize the `orPattern` method:
+
+```php
+EloquentRegex::builder()->start()
+    ->exact("alt=")
+    ->group(function ($pattern) {
+        $pattern->doubleQuote()
+        ->orPattern(function ($pattern) {
+            $pattern->singleQuote();
+        });
+    })->toRegex(); // alt\=(\"|')
+```
+
+In this example, we precisely match "alt=" using the `exact` method. We then create a group with the `group` method and include `doubleQuote` in group and then `singleQuote` within the orPattern method's callback. This approach ensures the pattern matches either " or '.
+
+The `orPattern` method also accepts a quantifier as its **second argument** (after callback), applying the same [quantifier logic](#quantifier-values) as elsewhere in EloquentRegex. This feature adds another layer of flexibility, allowing you to specify how many times either pattern should be present.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ EloquentRegex brings the simplicity and elegance to regular expressions. Designe
     - [Capturing Groups](#capturing-groups)
     - [Non-Capturing Groups](#non-capturing-groups)
     - [Groups with quantifier](#groups-with-quantifier)
+  - [Conditional matching](#conditional-matching)
 
 # Overview
 
@@ -869,6 +870,7 @@ EloquentRegex::start($string)
   - dateFormat, timeFormat: Specify the format of date and time (e.g., MM-DD-YYYY, HH:MM).
 - Consider to register Patterns like options using key (name) => value (class) pairs (check performance) ✔️ (_No significant change before 50+ patterns_)
 - Return collection on get method if laravel is available.
+- Add builderPattern methods list MD file and link from the Docs.
 - Implement usage of named groups: `/(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})/`
 
 - Write documentation (add credit for https://regexr.com/ and ChatGPT)
@@ -888,7 +890,7 @@ EloquentRegex::start($string)
   - Add sections:
     - Testing and Debugging
     - Credits
-    - Contributing
+    - Contributing (+STRUCTURE.md)
     - FAQs
     - Creating new patterns
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ $isValid = EloquentRegex::source('test@example.com')->email()->check();
 - **Options and Filters**: Tailor your regex operations with options and filters for precision matching. It's like having a regex wizard at your fingertips.
 - **Laravel Integration**: Seamlessly integrates with your Laravel projects, leveraging Laravel's elegant syntax and features.
 
+_For more details about package and it's inner workings check out [STRUCTURE.md](https://github.com/MaestroError/eloquent-regex/blob/update-documentation-and-add-advanced-usage-section/STRUCTURE.md) file._
+
 ## Getting Started
 
 Simply install the package via Composer, and you're ready to take the pain out of regex in your PHP/Laravel applications. Follow our quick start guide below to dive in.
@@ -122,22 +124,23 @@ Here you can check all available methods of ready-to-use patterns and their argu
 
 ```php
 public function textOrNumbers(
-    int $minLength,
-    int $maxLength,
-    int $minUppercase,
-    int $minLowercase,
-    int $minNumbers,
-    int $maxNumbers
-  );
+  int $minLength,
+  int $maxLength,
+  int $minUppercase,
+  int $minLowercase,
+  int $minNumbers,
+  int $maxNumbers
+);
 ```
 
 ```php
-// $onlyDomains & $onlyExtensions array or string separated by comma `"example.org,example.com"`
+// $onlyDomains & $onlyExtensions array
+// or string separated by comma `"example.org,example.com"`
 public function email(
-    int $maxLength,
-    array|string $onlyDomains,
-    array|string $onlyExtensions
-  );
+  int $maxLength,
+  array|string $onlyDomains,
+  array|string $onlyExtensions
+);
 ```
 
 ```php
@@ -147,10 +150,10 @@ public function url(array|string $onlyProtocol);
 ```php
 // $onlyDomains & $onlyExtensions array or string separated by comma "org,com"
 public function domainName(
-    int $maxLength,
-    array|string $onlyDomains,
-    array|string $onlyExtensions
-  );
+  int $maxLength,
+  array|string $onlyDomains,
+  array|string $onlyExtensions
+);
 ```
 
 ```php
@@ -185,11 +188,11 @@ public function username(int $maxLength);
 
 ```php
 public function password(
-    int $minLength,
-    int $minUppercase,
-    int $minNumbers,
-    int $minSpecialChars
-  );
+  int $minLength,
+  int $minUppercase,
+  int $minNumbers,
+  int $minSpecialChars
+);
 ```
 
 ```php
@@ -202,24 +205,28 @@ public function htmlTag(array|string $restrictTags, array|string $onlyTags);
 ```php
 // $specificCurrencies array of currency symbols or string separated by comma "$, ₾"
 public function currency(
-    int $minDigits,
-    int $maxDigits,
-    array|string $specificCurrencies
-  );
+  int $minDigits,
+  int $maxDigits,
+  array|string $specificCurrencies
+);
 ```
 
 ```php
 // $pathType allowed values: "absolute" & "relative"
 public function filePath(
-    int $isDirectory,
-    bool $isFile,
-    bool $fileExists,
-    string $pathType
-  );
+  int $isDirectory,
+  bool $isFile,
+  bool $fileExists,
+  string $pathType
+);
 ```
 
 ```php
-public function filePathWin(int $isDirectory, bool $isFile, bool $fileExists);
+public function filePathWin(
+  int $isDirectory,
+  bool $isFile,
+  bool $fileExists
+);
 ```
 
 Didn't it cover all your needs? Let's take a look to the custom patterns section.

--- a/README.md
+++ b/README.md
@@ -121,76 +121,76 @@ We have different ways to apply options, but the most common and easy way is to 
 Here you can check all available methods of ready-to-use patterns and their arguments:
 
 ```php
-textOrNumbers(int $minLength, int $maxLength, int $minUppercase, int $minLowercase, int $minNumbers, int $maxNumbers)
+public function textOrNumbers(int $minLength, int $maxLength, int $minUppercase, int $minLowercase, int $minNumbers, int $maxNumbers)
 ```
 
 ```php
 // $onlyDomains & $onlyExtensions array or string separated by comma `"example.org,example.com"`
-email(int $maxLength, array|string $onlyDomains, array|string $onlyExtensions)`
+public function email(int $maxLength, array|string $onlyDomains, array|string $onlyExtensions)`
 ```
 
 ```php
-url(array|string $onlyProtocol)`
+public function url(array|string $onlyProtocol)`
 ```
 
 ```php
 // $onlyDomains & $onlyExtensions array or string separated by comma "org,com"
-domainName(int $maxLength, array|string $onlyDomains, array|string $onlyExtensions)`
+public function domainName(int $maxLength, array|string $onlyDomains, array|string $onlyExtensions)`
 ```
 
 ```php
-date()
+public function date()
 ```
 
 ```php
-time()
+public function time()
 ```
 
 ```php
-ipAddress()
+public function ipAddress()
 ```
 
 ```php
-ipv6Address()
+public function ipv6Address()
 ```
 
 ```php
 // $cardTypes string separated by comma "visa, amex"
-creditCardNumber(string $cardTypes)
+public function creditCardNumber(string $cardTypes)
 ```
 
 ```php
 // $countryCode should passed without "+" sign: phone("1"), phone("995")
-phone(string $countryCode)
+public function phone(string $countryCode)
 ```
 
 ```php
-username(int $maxLength)
+public function username(int $maxLength)
 ```
 
 ```php
-password(int $minLength, int $minUppercase, int $minNumbers, int $minSpecialChars)
+public function password(int $minLength, int $minUppercase, int $minNumbers, int $minSpecialChars)
 ```
 
 ```php
 // $restrictTags & $onlyTags array or string
 // separated by comma `"script, style"`.
 // It isn't recomended to use both option simultaneously
-htmlTag(array|string $restrictTags, array|string $onlyTags)
+public function htmlTag(array|string $restrictTags, array|string $onlyTags)
 ```
 
 ```php
 // $specificCurrencies array of currency symbols or string separated by comma "$, ₾"
-currency(int $minDigits, int $maxDigits, array|string $specificCurrencies)
+public function currency(int $minDigits, int $maxDigits, array|string $specificCurrencies)
 ```
 
 ```php
 // $pathType allowed values: "absolute" & "relative"
-filePath(int $isDirectory, bool $isFile, bool $fileExists,string $pathType) -
+public function filePath(int $isDirectory, bool $isFile, bool $fileExists,string $pathType) -
 ```
 
 ```php
-filePathWin(int $isDirectory, bool $isFile, bool $fileExists)
+public function filePathWin(int $isDirectory, bool $isFile, bool $fileExists)
 ```
 
 Didn't it cover all your needs? Let's take a look to the custom patterns section.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ EloquentRegex brings the simplicity and elegance to regular expressions. Designe
     - [Options as extra assertions](#options-as-extra-assertions)
     - [Options as filters](#options-as-filters)
     - [Options list](#options-list)
+    - [Options in custom patterns](#options-in-custom-patterns)
+  - [Regex Flags](#regex-flags)
+    - [Case-Insensitive Matching](#case-Insensitive-matching)
+    - [Multiline Matching](#multiline-matching)
+    - [Single-Line Mode](#single-line-mode)
+    - [Unicode Character Matching](#unicode-character-matching)
 
 # Overview
 
@@ -448,8 +454,22 @@ Using custom pattern is greate way to cover specific use cases, but there can be
 
 ```php
 // example of using end() method with config array
+EloquentRegex::customPattern("Users: user_123, JohnDoe_99")
+  ->alphanumeric()
+  ->underscore()
+  ->digitsRange(0, 2)
+  ->end(["minLength" => 10])
+  ->checkString();
 
 // example of using end() method with callback
+$check = EloquentRegex::customPattern("Users: user_123, JohnDoe_99")
+  ->alphanumeric()
+  ->underscore()
+  ->digits()
+  ->end(function ($p) {
+      $p->minLength(10)->maxDigits(2);
+  })
+  ->checkString();
 ```
 
 ### Options list
@@ -589,10 +609,6 @@ Regex flags are special tokens that modify the behavior of regular expressions, 
 
 Sometimes, the case of letters in a string should not affect the match. To achieve case-insensitive matching, use the asCaseInsensitive() flag.
 
-### Multiline Matching
-
-The multiline flag allows the start (^) and end ($) anchors to match the start and end of lines within a string, rather than the entire string.
-
 ```php
 // When $string can be "Example@Email.COM", or "EXAMPLE@Email.com", or "example@EMAIL.COM" and etc.
 $checkWithFlag = EloquentRegex::source($string)
@@ -606,6 +622,10 @@ $checkWithFlag = EloquentRegex::source($string)
 // With the case-insensitive flag, the match succeeds.
 expect($checkWithFlag)->toBeTrue();
 ```
+
+### Multiline Matching
+
+The multiline flag allows the start (^) and end ($) anchors to match the start and end of lines within a string, rather than the entire string.
 
 **Example: Matching Dates Across Multiple Lines using check() method**
 
@@ -657,6 +677,7 @@ expect($matches)->toContain('და'); // Matches Unicode characters with the Un
 ##### To Do
 
 - Add options for new patterns:
+  - Add `contains` and `notContains` options
   - usernameLength: Set minimum and maximum length for the username part of the email.
   - dateFormat, timeFormat: Specify the format of date and time (e.g., MM-DD-YYYY, HH:MM).
 - Consider to register Patterns like options using key (name) => value (class) pairs (check performance) ✔️ (_No significant change before 50+ patterns_)

--- a/README.md
+++ b/README.md
@@ -59,12 +59,18 @@ $link = 'https://www.example.com/home';
 $isValidUrl = EloquentRegex::source($link)->url()->check();
 ```
 
-**Or**
+**Another:**
 
 ```php
 $isStrong = EloquentRegex::source("StrongP@ssw0rd")->password(function($string) {
     return $string->minLength(8)->minUppercase(1)->minNumbers(1)->minSpecialChars(1);
 })->check();
+```
+
+**One more:** 😄
+
+```php
+EloquentRegex::start("#hello #world This is a #test")->hash()->text()->get();
 ```
 
 ## Key Features

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Like what we're doing? Show your support with a quick star, please! ⭐
     - 💠 [Non-Capturing Groups](#non-capturing-groups)
     - 💠 [Groups with quantifier](#groups-with-quantifier)
   - ❓[Conditional matching](#conditional-matching)
-  - [Pattern alternation (orPattern)](#pattern-alternation-orpattern)
+  - ⚖️[Pattern alternation (orPattern)](#pattern-alternation-orpattern)
 
 # Overview
 
@@ -77,7 +77,7 @@ EloquentRegex::start("#hello #world This is a #test")->hash()->text()->get();
 // ['#hello', '#world', '#test']
 ```
 
-## Key Features
+## Key Features🔑
 
 - **Ready-to-Use Patterns**: Common patterns like emails, URLs, and IP addresses are pre-defined and ready to go. Just a few keystrokes and you're validating.
 - **Custom Patterns Made Easy**: Build your own regex patterns with an easy-to-use, fluent interface. Say hello to readable regex!
@@ -86,7 +86,7 @@ EloquentRegex::start("#hello #world This is a #test")->hash()->text()->get();
 
 _For more details about package and it's inner workings check out [STRUCTURE.md](https://github.com/MaestroError/eloquent-regex/blob/update-documentation-and-add-advanced-usage-section/STRUCTURE.md) file._
 
-## Getting Started
+## Getting Started🧭
 
 Simply install the package via Composer, and you're ready to take the pain out of regex in your PHP/Laravel applications. Run for installation:
 
@@ -155,7 +155,7 @@ EloquentRegex::source($yourString)->url()->count();
 EloquentRegex::source($yourString)->url()->toRegex();
 ```
 
-## Ready-to-Use Patterns
+## Ready-to-Use Patterns📑
 
 EloquentRegex comes with a set of predefined patterns for common validation/extraction tasks. These patterns are designed to be straightforward and easy to use, requiring minimal effort to implement.
 
@@ -272,7 +272,7 @@ public function filePathWin(
 
 Didn't it cover all your needs? Let's take a look to the custom patterns section.
 
-## Custom Patterns
+## Custom Patterns🛠️
 
 For scenarios where predefined patterns do not suffice, EloquentRegex allows you to define custom patterns using the start or customPattern methods as initiator:
 
@@ -311,7 +311,7 @@ Custom pattern builder supports a wide range of character classes and all specia
 - [Groups](https://github.com/MaestroError/eloquent-regex/blob/documentation-and-examples/src/Traits/BuilderPatternTraits/GroupsTrait.php)
 - [Anchors](https://github.com/MaestroError/eloquent-regex/blob/documentation-and-examples/src/Traits/BuilderPatternTraits/AnchorsTrait.php)
 
-## Applying Quantifiers
+## Applying Quantifiers#️⃣
 
 Quantifiers in regular expressions are symbols or sets of symbols that specify how many instances of a character, group, or character class must be present in the input for a match to be found. EloquentRegex enhances the way quantifiers are used, making it simpler and more intuitive to define the frequency of pattern occurrences.
 
@@ -416,7 +416,7 @@ As you become more comfortable with the basics of EloquentRegex, you might find 
 
 Whether you're dealing with intricate string formats, dynamic pattern requirements, or simply looking to optimize your regex operations for performance and clarity, this section will guide you through the advanced features of EloquentRegex. You'll learn how to leverage the full power of this package to make your Laravel application's text processing as efficient and effective as possible.
 
-## Options
+## Options⚙️
 
 EloquentRegex provides a flexible system for applying options to your patterns. These options can serve as extra assertions to refine pattern matching or act as filters to select only specific matches. There are three main ways to apply options: directly as arguments, through a callback, and via an associative array.
 
@@ -631,7 +631,7 @@ public function onlyTags(array|string $tags);
 public function restrictTags(array|string $tags);
 ```
 
-## Regex Flags
+## Regex Flags🚩
 
 Regex flags are special tokens that modify the behavior of regular expressions, allowing for more flexible and powerful pattern matching. In EloquentRegex, applying regex flags to your patterns enables specialized matching behaviors such as case-insensitive searches, multiline matching, single-line mode, and support for Unicode characters. Let's explore how to apply these flags using examples.
 
@@ -706,7 +706,7 @@ expect($matches)->toContain('და'); // Matches Unicode characters with the Un
 
 In addition to character classes and special character methods, builderPattern has more advanced methods for increasing flexibility and usage scope. Below are described the methods for the builderPattern's advanced usage.
 
-## Character Sets
+## Character Sets🗃️
 
 In regular expressions, character sets are a fundamental concept that allows you to define a set of characters to match within a single position in the input string. EloquentRegex provides an intuitive way to work with both positive and negative character sets, enhancing the versatility of your patterns.
 
@@ -753,7 +753,7 @@ When working with character sets in EloquentRegex, it's important to remember th
 
 _Update: From now, **0 as argument is optional**, because character classes willn't add default "+" quantifier inside the set_
 
-## Groups
+## Groups📦
 
 EloquentRegex simplifies the process of creating both capturing and non-capturing groups, allowing you to organize your regex patterns into logical sections and apply quantifiers or assertions to these groups as a whole.
 
@@ -820,7 +820,7 @@ EloquentRegex::start("345-45, 125-787, 344643")
 // It returns array: ["345-45", "125-787"]
 ```
 
-## Conditional matching
+## Conditional matching❓
 
 Assertion groups allow for conditional matching based on the presence (positive) or absence (negative) of patterns ahead or behind the current match point, without consuming characters from the string, so that anything inside assertion group willn't be added in matches. See examples below:
 
@@ -934,7 +934,7 @@ The `orPattern` method also accepts a quantifier as its **second argument** (aft
     - Grouping and Capturing: How to use groups (capturing and non-capturing) and apply quantifiers to them. ✔️
     - Sets ✔️
     - Lookaheads ✔️
-    - orPattern
+    - orPattern ✔️
     - Raw methods
     - Add section in docs for "lazy" method
   - Add sections:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ EloquentRegex brings the simplicity and elegance to regular expressions. Designe
     - [Custom Character Sets and Groups](#to-custom-character-sets-and-groups)
     - [Quantifier Values](#quantifier-values)
 - [Advanced usage](#advanced-usage)
-  - [Options]
+  - [Options](#options)
     - [Options as extra assertions](#options-as-extra-assertions)
     - [Options as filters](#options-as-filters)
     - [Options list](#options-list)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ EloquentRegex brings the simplicity and elegance to regular expressions. Designe
     - [Multiline Matching](#multiline-matching)
     - [Single-Line Mode](#single-line-mode)
     - [Unicode Character Matching](#unicode-character-matching)
+- [Advanced builderPattern methods](#advanced-builderpattern-methods)
   - [Character Sets](#character-sets)
   - [Groups](#groups)
     - [Capturing Groups](#capturing-groups)
@@ -678,9 +679,13 @@ expect($matches)->toContain('და'); // Matches Unicode characters with the Un
 
 ```
 
+# Advanced builderPattern methods
+
+In addition to character classes and special character methods, builderPattern has more advanced methods for increasing flexibility and usage scope. Below are described the methods for the builderPattern's advanced usage.
+
 ## Character Sets
 
-In regular expressions, character sets are a fundamental concept that allows you to define a set of characters to match within a single position in the input string. EloquentRegex provides an intuitive way to work with both positive and negative character sets, enhancing the versatility of your patterns. In character sets the order of characters isn't allow
+In regular expressions, character sets are a fundamental concept that allows you to define a set of characters to match within a single position in the input string. EloquentRegex provides an intuitive way to work with both positive and negative character sets, enhancing the versatility of your patterns.
 
 <!-- No quantifiers allowed inside set, cause it is parsed as symbols, so 0 (int) should be used where quantifier is enabled -->
 
@@ -692,7 +697,7 @@ A positive character set matches any one of the characters included within the s
 
 ```php
 // Matches exactly 3 occurrences of periods or colons
-EloquentRegex::source(".:.")
+EloquentRegex::start(".:.")
 ->charSet(function ($pattern) {
     $pattern->period()->colon();
 }, '3')->check();
@@ -734,7 +739,7 @@ EloquentRegex simplifies the process of creating both capturing and non-capturin
 Capturing groups are used to group part of a pattern together and capture the matching text for later use. Note that it returs array/collection with different structure while using with get:
 
 ```php
-// Matching a date format across multiple lines without capturing the groups
+// Matching a date format with capturing the parts as separated groups
 $result = EloquentRegex::start("2024-01-30, 2023-02-20")
 ->group(function($pattern) {
     $pattern->digits(4); // Year
@@ -766,7 +771,7 @@ $result = EloquentRegex::start("2024-01-30, 2023-02-20")
 
 ### Non-Capturing Groups
 
-Non-capturing groups organize patterns logically without capturing the matched text.
+Non-capturing groups organize patterns logically without capturing separately the matched text.
 
 ```php
 // Reproduces an 'alt' html property pattern fron HSA
@@ -881,6 +886,7 @@ EloquentRegex::start($string)
     - Options list ✔️
     - Ensure digits / digit behavior. ✔️
     - Regex Flags: Guide on applying regex flags to patterns for specialized matching behavior. ✔️
+  - Add advanced BuilderPattern methods:
     - Grouping and Capturing: How to use groups (capturing and non-capturing) and apply quantifiers to them. ✔️
     - Sets ✔️
     - Lookaheads ✔️

--- a/README.md
+++ b/README.md
@@ -121,76 +121,105 @@ We have different ways to apply options, but the most common and easy way is to 
 Here you can check all available methods of ready-to-use patterns and their arguments:
 
 ```php
-public function textOrNumbers(int $minLength, int $maxLength, int $minUppercase, int $minLowercase, int $minNumbers, int $maxNumbers)
+public function textOrNumbers(
+    int $minLength,
+    int $maxLength,
+    int $minUppercase,
+    int $minLowercase,
+    int $minNumbers,
+    int $maxNumbers
+  );
 ```
 
 ```php
 // $onlyDomains & $onlyExtensions array or string separated by comma `"example.org,example.com"`
-public function email(int $maxLength, array|string $onlyDomains, array|string $onlyExtensions)`
+public function email(
+    int $maxLength,
+    array|string $onlyDomains,
+    array|string $onlyExtensions
+  );
 ```
 
 ```php
-public function url(array|string $onlyProtocol)`
+public function url(array|string $onlyProtocol);
 ```
 
 ```php
 // $onlyDomains & $onlyExtensions array or string separated by comma "org,com"
-public function domainName(int $maxLength, array|string $onlyDomains, array|string $onlyExtensions)`
+public function domainName(
+    int $maxLength,
+    array|string $onlyDomains,
+    array|string $onlyExtensions
+  );
 ```
 
 ```php
-public function date()
+public function date();
 ```
 
 ```php
-public function time()
+public function time();
 ```
 
 ```php
-public function ipAddress()
+public function ipAddress();
 ```
 
 ```php
-public function ipv6Address()
+public function ipv6Address();
 ```
 
 ```php
 // $cardTypes string separated by comma "visa, amex"
-public function creditCardNumber(string $cardTypes)
+public function creditCardNumber(string $cardTypes);
 ```
 
 ```php
 // $countryCode should passed without "+" sign: phone("1"), phone("995")
-public function phone(string $countryCode)
+public function phone(string $countryCode);
 ```
 
 ```php
-public function username(int $maxLength)
+public function username(int $maxLength);
 ```
 
 ```php
-public function password(int $minLength, int $minUppercase, int $minNumbers, int $minSpecialChars)
+public function password(
+    int $minLength,
+    int $minUppercase,
+    int $minNumbers,
+    int $minSpecialChars
+  );
 ```
 
 ```php
 // $restrictTags & $onlyTags array or string
 // separated by comma `"script, style"`.
 // It isn't recomended to use both option simultaneously
-public function htmlTag(array|string $restrictTags, array|string $onlyTags)
+public function htmlTag(array|string $restrictTags, array|string $onlyTags);
 ```
 
 ```php
 // $specificCurrencies array of currency symbols or string separated by comma "$, ₾"
-public function currency(int $minDigits, int $maxDigits, array|string $specificCurrencies)
+public function currency(
+    int $minDigits,
+    int $maxDigits,
+    array|string $specificCurrencies
+  );
 ```
 
 ```php
 // $pathType allowed values: "absolute" & "relative"
-public function filePath(int $isDirectory, bool $isFile, bool $fileExists,string $pathType) -
+public function filePath(
+    int $isDirectory,
+    bool $isFile,
+    bool $fileExists,
+    string $pathType
+  );
 ```
 
 ```php
-public function filePathWin(int $isDirectory, bool $isFile, bool $fileExists)
+public function filePathWin(int $isDirectory, bool $isFile, bool $fileExists);
 ```
 
 Didn't it cover all your needs? Let's take a look to the custom patterns section.

--- a/README.md
+++ b/README.md
@@ -444,8 +444,12 @@ $cards = EloquentRegex::source($string)->creditCardNumber("visa, amex")->get();
 
 ### Options in custom patterns
 
+Using custom pattern is greate way to cover specific use cases, but there can be a moment when you need extra assertion or filter for you matches. While the `end()` method if optional by default, if you need to apply the **Options** to yor custom pattern, you should pass array or callback to the `end()` method:
+
 ```php
-// example of using end() method with option
+// example of using end() method with config array
+
+// example of using end() method with callback
 ```
 
 ### Options list
@@ -577,6 +581,77 @@ public function onlyTags(array|string $tags);
 public function restrictTags(array|string $tags);
 ```
 
+## Regex Flags
+
+Regex flags are special tokens that modify the behavior of regular expressions, allowing for more flexible and powerful pattern matching. In EloquentRegex, applying regex flags to your patterns enables specialized matching behaviors such as case-insensitive searches, multiline matching, single-line mode, and support for Unicode characters. Let's explore how to apply these flags using examples.
+
+### Case-Insensitive Matching
+
+Sometimes, the case of letters in a string should not affect the match. To achieve case-insensitive matching, use the asCaseInsensitive() flag.
+
+### Multiline Matching
+
+The multiline flag allows the start (^) and end ($) anchors to match the start and end of lines within a string, rather than the entire string.
+
+```php
+// When $string can be "Example@Email.COM", or "EXAMPLE@Email.com", or "example@EMAIL.COM" and etc.
+$checkWithFlag = EloquentRegex::source($string)
+                ->start()
+                ->exact("example")
+                ->character("@")
+                ->exact("email.com")
+                ->end()
+                ->asCaseInsensitive()->check();
+
+// With the case-insensitive flag, the match succeeds.
+expect($checkWithFlag)->toBeTrue();
+```
+
+**Example: Matching Dates Across Multiple Lines using check() method**
+
+```php
+$string = "2024-01-30\n2024-02-15\n2024-11-30";
+$matches = EloquentRegex::source($string)
+            ->start()
+            ->digits(4)->dash()
+            ->digits(2)->dash()
+            ->digits(2)
+            ->end() // Here you can apply options
+            ->asMultiline()->check();
+expect($matches)->toBeTrue();
+```
+
+_Note: if you need to check if string contains a date, using checkString() method is enough. In this example we are checking that every line is exactly the date._
+
+### Single-Line Mode
+
+In single-line mode, the dot (.) matches every character, including newline characters, allowing patterns to match across lines.
+
+**Example: Matching Text Across Lines as a Single Line String using check() method**
+
+```php
+$string = "Check out\n this site:";
+$check = EloquentRegex::source($string)
+          ->start()->anyChars()->character(":")->end()->asSingleline()
+          ->check();
+expect($check)->toBeTrue(); // Matches across lines due to the single-line flag.
+
+```
+
+### Unicode Character Matching
+
+When working with texts containing Unicode characters, the Unicode flag ensures that character classes such as \w (word characters - `wordChars` method) and \d (digits - `digits` method) correctly match Unicode characters.
+
+**Example: Matching Text with Unicode Characters**
+
+```php
+$string = "მზადაა #1 ✔️ და #2 ✔️";
+$matches = EloquentRegex::source($string)
+            ->start()->wordCharsRange(0, 2)->end()->asUnicode()->get();
+expect($matches)->toContain('და'); // Matches Unicode characters with the Unicode flag.
+
+```
+
 ---
 
 ##### To Do
@@ -592,8 +667,9 @@ public function restrictTags(array|string $tags);
   - Add advanced usage section in Docs:
     - Options and Assertions: Detailed explanation of options, how to apply them, and their effects on patterns. ✔️
     - Filters in Extraction: Using options as filters during extraction and the types of filters available. ✔️
-    - Options list
-    - Regex Flags: Guide on applying regex flags to patterns for specialized matching behavior.
+    - Options list ✔️
+    - Ensure digits / digit behavior. ✔️
+    - Regex Flags: Guide on applying regex flags to patterns for specialized matching behavior. ✔️
     - Grouping and Capturing: How to use groups (capturing and non-capturing) and apply quantifiers to them.
   - Add section in docs for "lazy" method
   - Add sections:

--- a/src/Contracts/BuilderContract.php
+++ b/src/Contracts/BuilderContract.php
@@ -85,6 +85,20 @@ interface BuilderContract {
     public function getPatterns(): array;
 
     /**
+     * Sets returnGroups property
+     *
+     * @return self Returns the Builder instance.
+     */
+    public function setReturnGroups(bool $enable): self;
+
+    /**
+     * Gets returnGroups property
+     *
+     * @return self Returns the Builder instance.
+     */
+    public function getReturnGroups(): bool;
+
+    /**
      * Magic method to handle dynamic method calls.
      *
      * This method is triggered when invoking inaccessible or non-existing methods.

--- a/src/Contracts/PatternContract.php
+++ b/src/Contracts/PatternContract.php
@@ -54,9 +54,10 @@ interface PatternContract {
      * Returns all matches found by this pattern.
      *
      * @param string $input The input string to validate.
+     * @param bool $returnGroups if true returns whole array of matches (including groups).
      * @return array all matches found in input.
      */
-    public function getMatches(string $input): ?array;
+    public function getMatches(string $input, bool $returnGroups = false): ?array;
 
     /**
      * Generates the regex pattern for input validation.

--- a/src/Options/SpecificCurrenciesOption.php
+++ b/src/Options/SpecificCurrenciesOption.php
@@ -40,29 +40,29 @@ class SpecificCurrenciesOption implements OptionContract {
         return $this;
     }
 
-    public function onlyUSD($cur = true) {
-        if ($cur) {
+    public function onlyUSD($only = true) {
+        if ($only) {
             $this->specificCurrencies = ["$"];
         }
         return $this;
     }
 
-    public function onlyEUR($cur = true) {
-        if ($cur) {
+    public function onlyEUR($only = true) {
+        if ($only) {
             $this->specificCurrencies = ["€"];
         }
         return $this;
     }
 
-    public function onlyGBP($cur = true) {
-        if ($cur) {
+    public function onlyGBP($only = true) {
+        if ($only) {
             $this->specificCurrencies = ["£"];
         }
         return $this;
     }
 
-    public function onlyGEL($cur = true) {
-        if ($cur) {
+    public function onlyGEL($only = true) {
+        if ($only) {
             $this->specificCurrencies = ["₾"];
         }
         return $this;

--- a/src/OptionsMapper.php
+++ b/src/OptionsMapper.php
@@ -42,7 +42,7 @@ class OptionsMapper {
         "maxDigits" => [NumberOption::class, "setMaxValue"],
         "numberAmount" => [NumberOption::class, "setExactValue"],
 
-        "allowChars" => [CharacterOption::class, "allow"],
+        "onlyChars" => [CharacterOption::class, "allow"],
         "excludeChars" => [CharacterOption::class, "exclude"],
         "minUppercase" => [CharacterOption::class, "minUppercase"],
         "minLowercase" => [CharacterOption::class, "minLowercase"],

--- a/src/OptionsMapper.php
+++ b/src/OptionsMapper.php
@@ -35,44 +35,59 @@ class OptionsMapper {
         "minLength" => [LengthOption::class, "minLength"],
         "maxLength" => [LengthOption::class, "maxLength"],
         "length" => [LengthOption::class, "exactLength"],
+
         "minNumbers" => [NumberOption::class, "setMinValue"],
         "maxNumbers" => [NumberOption::class, "setMaxValue"],
         "minDigits" => [NumberOption::class, "setMinValue"],
         "maxDigits" => [NumberOption::class, "setMaxValue"],
         "numberAmount" => [NumberOption::class, "setExactValue"],
+
         "allowChars" => [CharacterOption::class, "allow"],
         "excludeChars" => [CharacterOption::class, "exclude"],
         "minUppercase" => [CharacterOption::class, "minUppercase"],
         "minLowercase" => [CharacterOption::class, "minLowercase"],
-        "validIPv6" => [IPv6Option::class, "validIPv6"],
+        
         "minSpecialChars" => [CharOption::class, "minSpecialCharacters"],
         "maxSpecialChars" => [CharOption::class, "maxSpecialCharacters"],
         "onlyLowercase" => [CharOption::class, "onlyLowercase"],
         "onlyUppercase" => [CharOption::class, "onlyUppercase"],
+        "noSpecialChars" => [CharOption::class, "noSpecialCharacters"],
+        
+        "validIPv6" => [IPv6Option::class, "validIPv6"],
+
         "isFile" => [FileOption::class, "isFile"],
         "isDirectory" => [FileOption::class, "isDirectory"],
+        
         "fileExists" => [FileExistsOption::class, "fileExists"],
+
         "specificCurrencies" => [SpecificCurrenciesOption::class, "setSpecificCurrencies"],
         "onlyUSD" => [SpecificCurrenciesOption::class, "onlyUSD"],
         "onlyEUR" => [SpecificCurrenciesOption::class, "onlyEUR"],
         "onlyGBP" => [SpecificCurrenciesOption::class, "onlyGBP"],
         "onlyGEL" => [SpecificCurrenciesOption::class, "onlyGEL"],
+
         "pathType" => [PathTypeOption::class, "setPathType"],
+
         "countryCode" => [CountryCodeOption::class, "setCountryCode"],
-        "noSpecialChars" => [CharOption::class, "noSpecialCharacters"],
+
         "noSpaces" => [ContainSpacesOption::class, "noSpaces"],
         "noDoubleSpaces" => [ContainSpacesOption::class, "noDoubleSpaces"],
         "maxSpaces" => [ContainSpacesOption::class, "maxSpaces"],
+
         "onlyDomains" => [DomainSpecificOption::class, "setAllowedDomains"],
         "onlyExtensions" => [DomainSpecificOption::class, "setAllowedExtensions"],
+
         "onlyProtocol" => [ProtocolOption::class, "onlyProtocol"],
         "onlyHttp" => [ProtocolOption::class, "onlyHttp"],
         "onlyHttps" => [ProtocolOption::class, "onlyHttps"],
+
         "onlyVisa" => [CardTypeOption::class, "onlyVisa"],
         "onlyMasterCard" => [CardTypeOption::class, "onlyMasterCard"],
         "onlyAmex" => [CardTypeOption::class, "onlyAmex"],
         "cardTypes" => [CardTypeOption::class, "allowCardTypes"],
+
         "onlyAlphanumeric" => [OnlyAlphanumericOption::class, "onlyAlphanumeric"],
+
         "onlyTags" => [HtmlTagsOption::class, "allowTags"],
         "restrictTags" => [HtmlTagsOption::class, "restrictTags"],
     ];

--- a/src/Patterns/BuilderPattern.php
+++ b/src/Patterns/BuilderPattern.php
@@ -32,6 +32,11 @@ class BuilderPattern extends BasePattern {
     protected bool $lazy = false;
 
     /**
+     * @var bool Flag to indicate that pattern is used inside charSet (Auto remove of extra "[]").
+     */
+    protected bool $inCharSet = false;
+
+    /**
      * @var BuilderContract Reference to the main Builder object.
      */
     protected BuilderContract $builder; 
@@ -134,7 +139,7 @@ class BuilderPattern extends BasePattern {
         if (is_int($length) && $length > 0) {
             $qntf = "{" . $length . "}";
             return $this->lazy ? $this->addLazy($qntf) : $qntf;
-        } elseif ($length === 0) {
+        } elseif ($length === 0 || $this->inCharSet) {
             return "";
         }
     
@@ -172,6 +177,11 @@ class BuilderPattern extends BasePattern {
      */
     public function lazy(): self {
         $this->lazy = true;
+        return $this;
+    }
+
+    public function inCharSet(): self {
+        $this->inCharSet = true;
         return $this;
     }
 

--- a/src/Patterns/BuilderPattern.php
+++ b/src/Patterns/BuilderPattern.php
@@ -95,27 +95,27 @@ class BuilderPattern extends BasePattern {
         }
         
         if ($q == 'zeroOrMore' || $q == '0>' || $q == '0+' || $q == '*') {
-            $p = "(" . $pattern . ')*';
+            $p = "(?:" . $pattern . ')*';
             return $this->lazy ? $this->addLazy($p) : $p;
         } elseif ($q == 'oneOrMore' || $q == '1>' || $q == '1+' || $q == '+') {
-            $p = "(" . $pattern . ')+';
+            $p = "(?:" . $pattern . ')+';
             return $this->lazy ? $this->addLazy($p) : $p;
         } elseif ($q == 'optional' || $q == '?' || $q == '|') {
-            $p = "(" . $pattern . ')?';
+            $p = "(?:" . $pattern . ')?';
             return $this->lazy ? $this->addLazy($p) : $p;
         }
 
         if (is_int($q)) {
-            $p = "(" . $pattern . "){".$q."}";
+            $p = "(?:" . $pattern . "){".$q."}";
             return $this->lazy ? $this->addLazy($p) : $p;
         } elseif (preg_match("/^\d{1,10}$/", $q)) {
-            $p = "(" . $pattern . '){'.$q.'}';
+            $p = "(?:" . $pattern . '){'.$q.'}';
             return $this->lazy ? $this->addLazy($p) : $p;
         } elseif (preg_match("/^\d{1,10},\d{1,10}$/", $q)) {
             $range = explode(",", $q);
             $f = $range[0];
             $s = $range[1];
-            $p = "(" . $pattern . ")" . "{" . $f . "," . $s ."}";
+            $p = "(?:" . $pattern . ")" . "{" . $f . "," . $s ."}";
             return $this->lazy ? $this->addLazy($p) : $p;
         }
 

--- a/src/Traits/BuilderPatternTraits/CharacterClassesTrait.php
+++ b/src/Traits/BuilderPatternTraits/CharacterClassesTrait.php
@@ -27,7 +27,7 @@ trait CharacterClassesTrait {
     }
 
     private function handleTextLowercase($length = null, $minLength = 0, $maxLength = 0): void {
-        $this->pattern .= "[a-z]";
+        $this->pattern .= $this->inCharSet ? "a-z" : "[a-z]";
         $this->pattern .= $this->getLengthOption($length, $minLength, $maxLength);
     }
 
@@ -52,7 +52,7 @@ trait CharacterClassesTrait {
     }
     
     private function handleTextUppercase($length = null, $minLength = 0, $maxLength = 0) {
-        $this->pattern .= "[A-Z]";
+        $this->pattern .= $this->inCharSet ? "A-Z" : "[A-Z]";
         $this->pattern .= $this->getLengthOption($length, $minLength, $maxLength);
     }
 
@@ -67,7 +67,7 @@ trait CharacterClassesTrait {
     }
     
     private function handleText($length = null, $minLength = 0, $maxLength = 0) {
-        $this->pattern .= "[a-zA-Z]";  // Matches both uppercase and lowercase letters
+        $this->pattern .= $this->inCharSet ? "a-zA-Z" : "[a-zA-Z]";  // Matches both uppercase and lowercase letters
         $this->pattern .= $this->getLengthOption($length, $minLength, $maxLength);
     }
 
@@ -150,7 +150,7 @@ trait CharacterClassesTrait {
     }
     
     private function handleAlphanumeric($length = null, $minLength = 0, $maxLength = 0) {
-        $this->pattern .= "[a-zA-Z0-9]";  // Matches alphanumeric characters
+        $this->pattern .= $this->inCharSet ? "a-zA-Z0-9" : "[a-zA-Z0-9]";  // Matches alphanumeric characters
         $this->pattern .= $this->getLengthOption($length, $minLength, $maxLength);
     }
     

--- a/src/Traits/BuilderPatternTraits/CharacterClassesTrait.php
+++ b/src/Traits/BuilderPatternTraits/CharacterClassesTrait.php
@@ -100,6 +100,10 @@ trait CharacterClassesTrait {
         return $this->digits(1);  // Reuse the existing digits method
     }
     
+    public function number(): self {
+        return $this->digits(1);  // Reuse the existing digits method
+    }
+    
     private function handleDigits($length = null, $minLength = 0, $maxLength = 0) {
         $this->pattern .= "\\d";  // Matches digits
         $this->pattern .= $this->getLengthOption($length, $minLength, $maxLength);
@@ -108,6 +112,10 @@ trait CharacterClassesTrait {
     public function nonDigits($length = null): self {
         $this->handleNonDigits($length);
         return $this;
+    }
+
+    public function nonDigit(): self {
+        return $this->nonDigits(1);
     }
 
     public function nonDigitsRange($minLength = 0, $maxLength = 0): self {
@@ -176,12 +184,21 @@ trait CharacterClassesTrait {
         $this->pattern .= $this->getLengthOption($length, $minLength, $maxLength);
     }
 
-    public function wordChar($length = null): self {
+    public function wordChar(): self {
+        return $this->wordChars(1);
+    }
+
+    public function wordChars($length = null): self {
         $this->handleWordChar($length);
         return $this;
     }
 
     public function wordCharRange($minLength = 0, $maxLength = 0): self {
+        $this->handleWordChar(null, $minLength, $maxLength);
+        return $this;
+    }
+
+    public function wordCharsRange($minLength = 0, $maxLength = 0): self {
         $this->handleWordChar(null, $minLength, $maxLength);
         return $this;
     }
@@ -191,7 +208,12 @@ trait CharacterClassesTrait {
         $this->pattern .= $this->getLengthOption($length, $minLength, $maxLength);
     }
 
-    public function nonWordChar($length = null): self {
+    public function nonWordChar(): self {
+        $this->nonWordChars(1);
+        return $this;
+    }
+
+    public function nonWordChars($length = null): self {
         $this->handleNonWordChar($length);
         return $this;
     }
@@ -206,7 +228,11 @@ trait CharacterClassesTrait {
         $this->pattern .= $this->getLengthOption($length, $minLength, $maxLength);
     }
 
-    public function anyChar($length = null): self {
+    public function anyChar(): self {
+        return $this->anyChars(1);
+    }
+
+    public function anyChars($length = null): self {
         $this->handleAnyChar($length);
         return $this;
     }
@@ -214,6 +240,10 @@ trait CharacterClassesTrait {
     public function anyCharRange($minLength = 0, $maxLength = 0): self {
         $this->handleAnyChar(null, $minLength, $maxLength);
         return $this;
+    }
+    
+    public function anyCharsRange($minLength = 0, $maxLength = 0): self {
+        return $this->anyCharRange($minLength, $maxLength);
     }
     
     private function handleAnyChar($length = null, $minLength = 0, $maxLength = 0) {

--- a/src/Traits/BuilderPatternTraits/GroupsTrait.php
+++ b/src/Traits/BuilderPatternTraits/GroupsTrait.php
@@ -28,6 +28,7 @@ trait GroupsTrait {
      */
     public function negativeCharSet(callable $callback, ?string $q = null): self {
         $subPattern = new self();
+        $subPattern->inCharSet();
         $callback($subPattern);
         $p = '[^' . $subPattern->getPattern() . ']';
         $this->pattern .= $q ? $this->applyQuantifier($p, $q) : $p;

--- a/src/Traits/BuilderPatternTraits/GroupsTrait.php
+++ b/src/Traits/BuilderPatternTraits/GroupsTrait.php
@@ -150,8 +150,9 @@ trait GroupsTrait {
      * @param string $regex The regex string to wrap and add.
      * @return self
      */
-    public function addRawNonCapturingGroup(string $regex): self {
-        $this->pattern .= '(?:' . $regex . ')';
+    public function addRawNonCapturingGroup(string $regex, ?string $q = null): self {
+        $p = '(?:' . $regex . ')';
+        $this->pattern .= $q ? $this->applyQuantifier($p, $q) : $p;
         return $this;
     }
 

--- a/src/Traits/BuilderPatternTraits/GroupsTrait.php
+++ b/src/Traits/BuilderPatternTraits/GroupsTrait.php
@@ -42,6 +42,7 @@ trait GroupsTrait {
      * @return self
      */
     public function group(callable $callback, ?string $q = null): self {
+        $this->builder->setReturnGroups(true);
         $subPattern = new self();
         $callback($subPattern);
         $p = $subPattern->getPattern();

--- a/src/Traits/BuilderPatternTraits/SpecificCharsTrait.php
+++ b/src/Traits/BuilderPatternTraits/SpecificCharsTrait.php
@@ -9,7 +9,7 @@ trait SpecificCharsTrait {
     private function handleExact(string|array $string, $caseSensitive = true, $quantifier = null) {
         if (is_array($string)) {
             $string = $this->escapeArray($string);
-            $escapedString = "(" . implode("|", $string) . ")";
+            $escapedString = "(?:" . implode("|", $string) . ")";
         } else {
             $escapedString = preg_quote($string, '/');
         }

--- a/tests/Feature/BuilderPatternTest.php
+++ b/tests/Feature/BuilderPatternTest.php
@@ -128,7 +128,7 @@ it('extracts secret coded messages from text', function () {
         ->lookBehind(function ($pattern) {
             $pattern->openCurlyBrace()->exact('secret: ');
         })
-        ->lazy()->anyChar()
+        ->lazy()->anyChars()
         ->lookAhead(function ($pattern) {
             $pattern->closeCurlyBrace();
         })

--- a/tests/Feature/BuilderPatternTest.php
+++ b/tests/Feature/BuilderPatternTest.php
@@ -63,7 +63,7 @@ it('constructs regex for URL validation', function () {
             ->text()
             ->toRegex();
 
-    expect($regex)->toBe('(http|https)\:\/\/[a-zA-Z]+\.[a-zA-Z]+');
+    expect($regex)->toBe('(?:http|https)\:\/\/[a-zA-Z]+\.[a-zA-Z]+');
 });
 
 it('constructs regex for specific phone number format', function () {

--- a/tests/Feature/EloquentRegexTest.php
+++ b/tests/Feature/EloquentRegexTest.php
@@ -83,11 +83,24 @@ it('extracts dates in specific format from text using wrapper', function () {
 });
 
 it('validates usernames in a string using wrapper and LengthOption', function () {
-    $check = EloquentRegex::customPattern("Users: user_123, JohnDoe99")
+    $check = EloquentRegex::customPattern("Users: user_123, JohnDoe_99")
         ->alphanumeric()
         ->underscore()
         ->digitsRange(0, 2)
-        ->end(["maxLength" => 15])
+        ->end(["minLength" => 10])
+        ->checkString();
+
+    expect($check)->toBeTrue();
+});
+
+it('validates usernames in a string using wrapper and callback options', function () {
+    $check = EloquentRegex::customPattern("Users: user_123, JohnDoe_99")
+        ->alphanumeric()
+        ->underscore()
+        ->digits()
+        ->end(function ($p) {
+            $p->minLength(10)->maxDigits(2);
+        })
         ->checkString();
 
     expect($check)->toBeTrue();

--- a/tests/Feature/EloquentRegexTest.php
+++ b/tests/Feature/EloquentRegexTest.php
@@ -306,10 +306,19 @@ it('matches a specific number of negative character sets', function () {
             // Inside set "+" is parsed as symbol, instead of quantifier
             // So, inside charSet and negativeCharSet method, you should
             // pass 0 as first argument to do not apply quantifier here
-            $pattern->digits(0); 
+            $pattern->digits();
         }, '2,4')->toRegex();
 
     expect($regex)->toBe('(?:[^\d]){2,4}');
+});
+
+it('matches a specific number of negative character sets using text method', function () {
+    $regex = EloquentRegex::builder()->start()
+        ->negativeCharSet(function ($pattern) {
+            $pattern->text();
+        }, '2,4')->toRegex();
+
+    expect($regex)->toBe('(?:[^a-zA-Z]){2,4}');
 });
 
 it('applies quantifier to capturing groups correctly', function () {

--- a/tests/Feature/EloquentRegexTest.php
+++ b/tests/Feature/EloquentRegexTest.php
@@ -108,7 +108,7 @@ it('extracts secret coded messages from text using wrapper', function () {
         ->lookBehind(function ($pattern) {
             $pattern->openCurlyBrace()->exact('secret: ');
         })
-        ->lazy()->anyChar()
+        ->lazy()->anyChars()
         ->lookAhead(function ($pattern) {
             $pattern->closeCurlyBrace();
         })
@@ -327,3 +327,18 @@ it('uses quantifier with alternation patterns correctly', function () {
 
     expect($regex)->toBe('([a-zA-Z]+|(\d+)?)');
 });
+
+// Regex flags tests:
+
+it('uses asCaseInsensitive method to match pattern correctly', function () {
+    $checkWithFlag = EloquentRegex::source("EXAMPLE@Email.com")
+        ->start()
+        ->exact("example")
+        ->character("@")
+        ->exact("email.com")
+        ->end()
+        ->asCaseInsensitive()->check();
+
+    expect($checkWithFlag)->toBeTrue();
+});
+

--- a/tests/Feature/Patterns/RegexFlagsTest.php
+++ b/tests/Feature/Patterns/RegexFlagsTest.php
@@ -43,13 +43,13 @@ it('matches dates across multiple lines', function () {
 it('matches a text in multiline as a single line string', function () {
     $string = "Check out\n this site:";
     $builder = new Builder($string);
-    $check = $builder->start()->anyChar()->character(":")->end()->asSingleline()->check();
+    $check = $builder->start()->anyChars()->character(":")->end()->asSingleline()->check();
     expect($check)->toBeTrue(); // It don't match without Singleline flag
 });
 
 it('matches text with Unicode characters', function () {
     $string = "მზადაა #1 ✔️ და #2 ✔️";
     $builder = new Builder($string);
-    $matches = $builder->start()->wordCharRange(0, 2)->end()->asUnicode()->get();
+    $matches = $builder->start()->wordCharsRange(0, 2)->end()->asUnicode()->get();
     expect($matches)->toContain('და'); // It don't match without unicode char
 });

--- a/tests/Unit/Patterns/BuilderPatternTest.php
+++ b/tests/Unit/Patterns/BuilderPatternTest.php
@@ -224,7 +224,7 @@ test('Escaped characters with quantifiers generate correct regex and match appro
     $builder->doubleQuote()->exact('quoted', true, '*')->doubleQuote();
 
     // $expectedPattern = '/"quoted*"/';
-    $expectedPattern = '/"(quoted)*"/'; // @todo Should return this
+    $expectedPattern = '/"(?:quoted)*"/'; // @todo Should return this
     $regex = $builder->getMatchesValidationPattern();
 
     expect($regex)->toBe($expectedPattern);

--- a/tests/Unit/Patterns/BuilderPatternTest.php
+++ b/tests/Unit/Patterns/BuilderPatternTest.php
@@ -305,7 +305,7 @@ test('nonWhitespace method matches non-whitespace characters', function () {
 
 test('wordChar method matches word characters', function () {
     $builder = new BuilderPattern();
-    $builder->wordChar(2); // Matches exactly 2 word characters
+    $builder->wordChars(2); // Matches exactly 2 word characters
     $regex = $builder->getInputValidationPattern();
     expect(preg_match($regex, 'Ab'))->toBe(1);
     expect(preg_match($regex, 'A1'))->toBe(1);
@@ -315,7 +315,7 @@ test('wordChar method matches word characters', function () {
 
 test('nonWordChar method matches non-word characters', function () {
     $builder = new BuilderPattern();
-    $builder->nonWordChar(2); // Matches exactly 2 non-word characters
+    $builder->nonWordChars(2); // Matches exactly 2 non-word characters
     $regex = $builder->getInputValidationPattern();
     expect(preg_match($regex, '--'))->toBe(1);
     expect(preg_match($regex, '!@'))->toBe(1);


### PR DESCRIPTION
- Return captured groups while using `group()` method with `get()`.✔️
- Remove default quantifier inside charSet.✔️
- Remove extra "[]" inside charSet.✔️
- Rename "allowChars" option to "onlyChars".✔️
---
- Add advanced usage section in Docs:
    - Options and Assertions: Detailed explanation of options, how to apply them, and their effects on patterns. ✔️
    - Filters in Extraction: Using options as filters during extraction and the types of filters available. ✔️
    - Options list ✔️
    - Ensure digits / digit behavior. ✔️
    - Regex Flags: Guide on applying regex flags to patterns for specialized matching behavior. ✔️
---
  - Add advanced BuilderPattern methods:
    - Grouping and Capturing: How to use groups (capturing and non-capturing) and apply quantifiers to them. ✔️
    - Sets ✔️
    - Lookaheads ✔️
    - orPattern ✔️
    - Raw methods ✔️
    - Add section in docs for "lazy" method ✔️